### PR TITLE
refactor: create separate files for various functions

### DIFF
--- a/src/commands/decomposer/compose.ts
+++ b/src/commands/decomposer/compose.ts
@@ -4,14 +4,11 @@ import * as path from 'node:path';
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import {
-  METADATA_DIR_DEFAULT_VALUE,
-  XML_HEADER,
-  NAMESPACE,
-  CUSTOM_LABELS_FILE,
-  INDENT,
-} from '../../helpers/constants.js';
+import { METADATA_DIR_DEFAULT_VALUE, CUSTOM_LABELS_FILE } from '../../helpers/constants.js';
 import jsonData from '../../metadata/metadata.js';
+import { Metadata } from '../../metadata/metadataInterface.js';
+import { getAttributesForMetadataType } from '../../service/getAttributesForMetadataType.js';
+import { composeAndWriteFile } from '../../service/composeAndWriteFile.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sfdx-decomposer', 'decomposer.compose');
@@ -118,36 +115,4 @@ export default class DecomposerCompose extends SfCommand<DecomposerComposeResult
     }
     this.log(`All metadata files have been composed for the metadata type: ${metaSuffix}`);
   }
-}
-interface Metadata {
-  directoryName: string;
-  metaSuffix: string;
-  xmlElement: string;
-}
-
-function getAttributesForMetadataType(jsonData: Metadata[], metadataType: string): Metadata | null {
-  const metadata = jsonData.find((item) => item.metaSuffix === metadataType);
-
-  if (metadata) {
-    return metadata;
-  }
-  return null;
-}
-
-function composeAndWriteFile(combinedXmlContents: string[], filePath: string, xmlElement: string): void {
-  // Combine XML contents into a single string
-  let finalXmlContent = combinedXmlContents.join('\n');
-
-  // Remove duplicate XML declarations
-  finalXmlContent = finalXmlContent.replace(/<\?xml version="1.0" encoding="UTF-8"\?>/g, '');
-
-  // Remove duplicate parent elements
-  finalXmlContent = finalXmlContent.replace(`<${xmlElement}>`, '');
-  finalXmlContent = finalXmlContent.replace(`</${xmlElement}>`, '');
-
-  // Remove extra newlines
-  finalXmlContent = finalXmlContent.replace(/(\n\s*){2,}/g, `\n${INDENT}`);
-
-  fs.writeFileSync(filePath, `${XML_HEADER}\n<${xmlElement} ${NAMESPACE}>${finalXmlContent}</${xmlElement}>`);
-  console.log(`Created composed file: ${filePath}`);
 }

--- a/src/commands/decomposer/compose.ts
+++ b/src/commands/decomposer/compose.ts
@@ -1,14 +1,11 @@
 /* eslint-disable */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import { METADATA_DIR_DEFAULT_VALUE, CUSTOM_LABELS_FILE } from '../../helpers/constants.js';
+import { METADATA_DIR_DEFAULT_VALUE } from '../../helpers/constants.js';
 import jsonData from '../../metadata/metadata.js';
 import { Metadata } from '../../metadata/metadataInterface.js';
 import { getAttributesForMetadataType } from '../../service/getAttributesForMetadataType.js';
-import { composeAndWriteFile } from '../../service/composeAndWriteFile.js';
+import { composeFileHandler } from '../../service/composeFileHandler.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sfdx-decomposer', 'decomposer.compose');
@@ -48,68 +45,13 @@ export default class DecomposerCompose extends SfCommand<DecomposerComposeResult
 
     if (metaAttributes) {
       const { metaSuffix, xmlElement, metadataPath } = metaAttributes;
-      this.parseMetadataFiles(metadataPath, metaSuffix, xmlElement);
+      composeFileHandler(metadataPath, metaSuffix, xmlElement);
+      this.log(`All metadata files have been composed for the metadata type: ${metaSuffix}`);
     } else {
       this.error(`Metadata type ${metadataTypeToRetrieve} not found.`);
     }
     return {
       path: 'sfdx-decomposer-plugin\\src\\commands\\decomposer\\compose.ts',
     };
-  }
-
-  private parseMetadataFiles(metadataPath: string, metaSuffix: string, xmlElement: string): void {
-    const processFilesInDirectory = (dirPath: string): string[] => {
-      const combinedXmlContents: string[] = [];
-      const files = fs.readdirSync(dirPath);
-
-      // Sort files based on the name
-      files.sort((fileA, fileB) => {
-        const fullNameA = fileA.split('.')[0].toLowerCase();
-        const fullNameB = fileB.split('.')[0].toLowerCase();
-        return fullNameA.localeCompare(fullNameB);
-      });
-
-      files.forEach((file) => {
-        const filePath = path.join(dirPath, file);
-
-        if (fs.statSync(filePath).isFile()) {
-          if (metaSuffix === 'labels' && !file.endsWith(`label-meta.xml`)) {
-            return; // Skip files that don't match the expected naming convention for custom labels
-          }
-
-          const xmlContent = fs.readFileSync(filePath, 'utf-8');
-          combinedXmlContents.push(xmlContent);
-        } else if (fs.statSync(filePath).isDirectory()) {
-          const subdirectoryContents = processFilesInDirectory(filePath);
-          combinedXmlContents.push(...subdirectoryContents); // Concatenate contents from subdirectories
-        }
-      });
-
-      return combinedXmlContents;
-    };
-
-    // Process labels in root metadata folder
-    // Process other metadata files in subdirectories
-    if (metaSuffix === 'labels') {
-      const combinedXmlContents: string[] = processFilesInDirectory(metadataPath);
-      const filePath = path.join(metadataPath, CUSTOM_LABELS_FILE);
-
-      composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
-    } else {
-      const subdirectories = fs
-        .readdirSync(metadataPath)
-        .map((file) => path.join(metadataPath, file))
-        .filter((filePath) => fs.statSync(filePath).isDirectory());
-
-      subdirectories.forEach((subdirectory) => {
-        this.log('Processing subdirectory:', subdirectory);
-        const combinedXmlContents: string[] = processFilesInDirectory(subdirectory);
-        const subdirectoryBasename = path.basename(subdirectory);
-        const filePath = path.join(metadataPath, `${subdirectoryBasename}.${metaSuffix}-meta.xml`);
-
-        composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
-      });
-    }
-    this.log(`All metadata files have been composed for the metadata type: ${metaSuffix}`);
   }
 }

--- a/src/commands/decomposer/compose.ts
+++ b/src/commands/decomposer/compose.ts
@@ -44,16 +44,13 @@ export default class DecomposerCompose extends SfCommand<DecomposerComposeResult
 
     const metadataTypeToRetrieve = flags['metadata-type'];
     const dxDirectory = flags['dx-directory'];
-    const metaAttributes = getAttributesForMetadataType(jsonData, metadataTypeToRetrieve);
+    const metaAttributes = getAttributesForMetadataType(jsonData, metadataTypeToRetrieve, dxDirectory);
 
     if (metaAttributes) {
-      const metaSuffix = metaAttributes.metaSuffix;
-      const directoryName = metaAttributes.directoryName;
-      const xmlElement = metaAttributes.xmlElement;
-      const metadataPath = `${dxDirectory}/${directoryName}`;
+      const { metaSuffix, xmlElement, metadataPath } = metaAttributes;
       this.parseMetadataFiles(metadataPath, metaSuffix, xmlElement);
     } else {
-      this.log(`Metadata type ${metadataTypeToRetrieve} not found.`);
+      this.error(`Metadata type ${metadataTypeToRetrieve} not found.`);
     }
     return {
       path: 'sfdx-decomposer-plugin\\src\\commands\\decomposer\\compose.ts',

--- a/src/commands/decomposer/compose.ts
+++ b/src/commands/decomposer/compose.ts
@@ -1,4 +1,5 @@
-/* eslint-disable */
+'use strict';
+
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
 import { METADATA_DIR_DEFAULT_VALUE } from '../../helpers/constants.js';

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -1,27 +1,18 @@
 /* eslint-disable */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { XMLParser } from 'fast-xml-parser';
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import { METADATA_DIR_DEFAULT_VALUE, XML_HEADER } from '../../helpers/constants.js';
+import { METADATA_DIR_DEFAULT_VALUE } from '../../helpers/constants.js';
 import jsonData from '../../metadata/metadata.js';
+import { Metadata } from '../../metadata/metadataInterface.js';
+import { getAttributesForMetadataType } from '../../service/getAttributesForMetadataType.js';
+import { xml2jsParser } from '../../service/xml2jsParser.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sfdx-decomposer', 'decomposer.decompose');
 const metaSuffixOptions = jsonData.map((item: Metadata) => item.metaSuffix);
-
-const XML_PARSER_OPTION = {
-  commentPropName: '#comment',
-  ignoreAttributes: false,
-  ignoreNameSpace: false,
-  parseTagValue: false,
-  parseNodeValue: false,
-  parseAttributeValue: false,
-  trimValues: true,
-  processEntities: false,
-};
 
 export type DecomposerDecomposeResult = {
   path: string;
@@ -86,186 +77,4 @@ export default class DecomposerDecompose extends SfCommand<DecomposerDecomposeRe
     });
     this.log(`All metadata files have been decomposed for the metadata type: ${metaSuffix}`);
   }
-}
-
-interface Metadata {
-  directoryName: string;
-  metaSuffix: string;
-  xmlElement: string;
-  fieldNames: string;
-}
-
-function getAttributesForMetadataType(jsonData: Metadata[], metadataType: string): Metadata | null {
-  const metadata = jsonData.find((item) => item.metaSuffix === metadataType);
-
-  if (metadata) {
-    return metadata;
-  }
-  return null;
-}
-
-function xml2jsParser(
-  xmlString: string,
-  metadataPath: string,
-  fieldNames: string,
-  xmlElement: string,
-  baseName: string,
-  metaSuffix: string,
-  indent: string = '    '
-): void {
-  try {
-    const xmlParser = new XMLParser(XML_PARSER_OPTION);
-    const result = xmlParser.parse(xmlString);
-
-    const rootElementName = Object.keys(result)[1];
-    const rootElement = result[rootElementName];
-    let leafContent = '';
-    let leafCount = 0;
-
-    // Iterate through child elements to find the field name for each
-    Object.keys(rootElement)
-      .filter((key: string) => !key.startsWith('@'))
-      .forEach((key: string) => {
-        if (Array.isArray(rootElement[key])) {
-          // Iterate through the elements of the array
-          for (const element of rootElement[key]) {
-            let elementContent = '';
-            elementContent += `${XML_HEADER}\n`;
-
-            const fieldName = findFieldName(element, fieldNames);
-            const outputDirectory = path.join(metadataPath, metaSuffix === 'labels' ? '' : key);
-            const outputFileName: string = `${fieldName}.${metaSuffix === 'labels' ? key.slice(0, -1) : key}-meta.xml`;
-            const outputPath = path.join(outputDirectory, outputFileName);
-
-            // Create the output directory if it doesn't exist
-            fs.mkdirSync(outputDirectory, { recursive: true });
-
-            // Call the printChildElements to build the XML content string
-            elementContent = printChildElements(element, key, elementContent);
-
-            // Write the XML content to the determined output path
-            fs.writeFileSync(outputPath, elementContent);
-
-            console.log(`XML content saved to: ${outputPath}`);
-          }
-        } else if (typeof rootElement[key] === 'object') {
-          let elementContent = '';
-          elementContent += `${XML_HEADER}\n`;
-
-          const fieldName = findFieldName(rootElement[key], fieldNames);
-
-          const outputDirectory = path.join(metadataPath, key);
-          const outputFileName: string = `${fieldName}.${metaSuffix === 'labels' ? key.slice(0, -1) : key}-meta.xml`;
-          const outputPath = path.join(outputDirectory, outputFileName);
-
-          // Create the output directory if it doesn't exist
-          fs.mkdirSync(outputDirectory, { recursive: true });
-
-          // Call the printChildElements to build the XML content string
-          elementContent = printChildElements(rootElement[key], key, elementContent);
-
-          // Write the XML content to the determined output path
-          fs.writeFileSync(outputPath, elementContent);
-
-          console.log(`XML content saved to: ${outputPath}`);
-        } else {
-          // Process XML elements that do not have children (e.g., leaf elements)
-          const fieldValue = rootElement[key];
-          // Append leaf element to the accumulated XML content
-          leafContent += `${indent}<${key}>${fieldValue}</${key}>\n`;
-          leafCount++;
-        }
-      });
-
-    if (leafCount > 0) {
-      let leafFile = `${XML_HEADER}\n`;
-      leafFile += `<${xmlElement}>\n`;
-
-      const sortedLeafContent = leafContent
-        .split('\n') // Split by lines
-        .filter((line) => line.trim() !== '') // Remove empty lines
-        .sort() // Sort alphabetically
-        .join('\n'); // Join back into a string
-      leafFile += sortedLeafContent;
-      leafFile += `\n</${xmlElement}>`;
-      const leafOutputPath = path.join(metadataPath, `${baseName}.${metaSuffix}-meta.xml`);
-      fs.writeFileSync(leafOutputPath, leafFile);
-
-      console.log(`All leaf elements saved to: ${leafOutputPath}`);
-    }
-  } catch (err) {
-    console.error('Error parsing XML:', err);
-  }
-}
-
-function findFieldName(element: any, fieldNames: string): string | undefined {
-  const fieldNamesArray = fieldNames.split(',');
-
-  for (const fieldName of fieldNamesArray) {
-    // Check if the current fieldName exists in the element
-    if (element[fieldName]) {
-      return element[fieldName];
-    }
-  }
-
-  // Iterate through child elements to find the field name
-  for (const key in element) {
-    if (typeof element[key] === 'object') {
-      const childFieldName = findFieldName(element[key], fieldNames);
-      if (childFieldName) {
-        return childFieldName;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function printChildElements(
-  element: any,
-  parentKey: string | null = null,
-  xmlContent: string,
-  indent: string = '    '
-): string {
-  // Recursive function to handle nested elements
-  function processElement(element: any, parentKey: string | null = null, currentIndent: string = ''): void {
-    if (typeof element === 'object') {
-      if (parentKey) {
-        xmlContent += `${currentIndent}<${parentKey}>\n`;
-      }
-
-      Object.entries(element).forEach(([key, value]) => {
-        if (key === '$') {
-          // Skip the special key representing attributes, like the namespace
-          return;
-        }
-
-        if (Array.isArray(value)) {
-          // Handle arrays of elements
-          value.forEach((arrayElement) => {
-            if (typeof arrayElement === 'object') {
-              processElement(arrayElement, key, `${currentIndent}${indent}`);
-            } else {
-              xmlContent += `${currentIndent}${indent}<${key}>${arrayElement}</${key}>\n`;
-            }
-          });
-        } else if (typeof value === 'object') {
-          // Recursively handle nested objects
-          processElement(value, key, `${currentIndent}${indent}`);
-        } else {
-          // Print regular key-value pairs
-          xmlContent += `${currentIndent}${indent}<${key}>${value}</${key}>\n`;
-        }
-      });
-
-      if (parentKey) {
-        xmlContent += `${currentIndent}</${parentKey}>\n`;
-      }
-    }
-  }
-
-  // Start processing with the initial indentation
-  processElement(element, parentKey, indent);
-
-  return xmlContent;
 }

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -44,17 +44,13 @@ export default class DecomposerDecompose extends SfCommand<DecomposerDecomposeRe
 
     const metadataTypeToRetrieve = flags['metadata-type'];
     const dxDirectory = flags['dx-directory'];
-    const metaAttributes = getAttributesForMetadataType(jsonData, metadataTypeToRetrieve);
+    const metaAttributes = getAttributesForMetadataType(jsonData, metadataTypeToRetrieve, dxDirectory);
 
     if (metaAttributes) {
-      const metaSuffix = metaAttributes.metaSuffix;
-      const directoryName = metaAttributes.directoryName;
-      const fieldNames = metaAttributes.fieldNames;
-      const xmlElement = metaAttributes.xmlElement;
-      const metadataPath = `${dxDirectory}/${directoryName}`;
+      const { metaSuffix, fieldNames, xmlElement, metadataPath } = metaAttributes;
       this.parseMetadataFiles(metadataPath, metaSuffix, fieldNames, xmlElement);
     } else {
-      this.log(`Metadata type ${metadataTypeToRetrieve} not found.`);
+      this.error(`Metadata type ${metadataTypeToRetrieve} not found.`);
     }
 
     return {

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -1,14 +1,11 @@
 /* eslint-disable */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import { INDENT, METADATA_DIR_DEFAULT_VALUE } from '../../helpers/constants.js';
+import { METADATA_DIR_DEFAULT_VALUE } from '../../helpers/constants.js';
 import jsonData from '../../metadata/metadata.js';
 import { Metadata } from '../../metadata/metadataInterface.js';
 import { getAttributesForMetadataType } from '../../service/getAttributesForMetadataType.js';
-import { xml2jsParser } from '../../service/xml2jsParser.js';
+import { decomposeFileHandler } from '../../service/decomposeFileHandler.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sfdx-decomposer', 'decomposer.decompose');
@@ -48,7 +45,8 @@ export default class DecomposerDecompose extends SfCommand<DecomposerDecomposeRe
 
     if (metaAttributes) {
       const { metaSuffix, fieldNames, xmlElement, metadataPath } = metaAttributes;
-      this.parseMetadataFiles(metadataPath, metaSuffix, fieldNames, xmlElement);
+      decomposeFileHandler(metadataPath, metaSuffix, fieldNames, xmlElement);
+      this.log(`All metadata files have been decomposed for the metadata type: ${metaSuffix}`);
     } else {
       this.error(`Metadata type ${metadataTypeToRetrieve} not found.`);
     }
@@ -56,21 +54,5 @@ export default class DecomposerDecompose extends SfCommand<DecomposerDecomposeRe
     return {
       path: 'sfdx-decomposer\\src\\commands\\decomposer\\decompose.ts',
     };
-  }
-
-  private parseMetadataFiles(metadataPath: string, metaSuffix: string, fieldNames: string, xmlElement: string): void {
-    const files = fs.readdirSync(metadataPath);
-    files.forEach((file) => {
-      const filePath = path.join(metadataPath, file);
-      if (file.endsWith(`.${metaSuffix}-meta.xml`)) {
-        // Add your logic to parse the metadata file here
-        this.log(`Parsing metadata file: ${filePath}`);
-        const xmlContent = fs.readFileSync(filePath, 'utf-8');
-        const baseName = path.basename(filePath, `.${metaSuffix}-meta.xml`);
-        const outputPath = path.join(metadataPath, metaSuffix === 'labels' ? '' : baseName);
-        xml2jsParser(xmlContent, outputPath, fieldNames, xmlElement, baseName, metaSuffix, INDENT);
-      }
-    });
-    this.log(`All metadata files have been decomposed for the metadata type: ${metaSuffix}`);
   }
 }

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
-import { METADATA_DIR_DEFAULT_VALUE } from '../../helpers/constants.js';
+import { INDENT, METADATA_DIR_DEFAULT_VALUE } from '../../helpers/constants.js';
 import jsonData from '../../metadata/metadata.js';
 import { Metadata } from '../../metadata/metadataInterface.js';
 import { getAttributesForMetadataType } from '../../service/getAttributesForMetadataType.js';
@@ -72,7 +72,7 @@ export default class DecomposerDecompose extends SfCommand<DecomposerDecomposeRe
         const xmlContent = fs.readFileSync(filePath, 'utf-8');
         const baseName = path.basename(filePath, `.${metaSuffix}-meta.xml`);
         const outputPath = path.join(metadataPath, metaSuffix === 'labels' ? '' : baseName);
-        xml2jsParser(xmlContent, outputPath, fieldNames, xmlElement, baseName, metaSuffix);
+        xml2jsParser(xmlContent, outputPath, fieldNames, xmlElement, baseName, metaSuffix, INDENT);
       }
     });
     this.log(`All metadata files have been decomposed for the metadata type: ${metaSuffix}`);

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -1,4 +1,5 @@
-/* eslint-disable */
+'use strict';
+
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
 import { METADATA_DIR_DEFAULT_VALUE } from '../../helpers/constants.js';

--- a/src/metadata/metadata.ts
+++ b/src/metadata/metadata.ts
@@ -1,113 +1,110 @@
-interface Metadata {
-  directoryName: string;
-  metaSuffix: string;
-  xmlElement: string;
-  fieldNames: string;
-}
+import { Metadata } from './metadataInterface.js';
 
 const jsonData: Metadata[] = [
-    {
-      'directoryName': 'labels',
-      'metaSuffix': 'labels',
-      'xmlElement': 'CustomLabels',
-      'fieldNames': 'fullName'
-    },
-    {
-      'directoryName': 'workflows',
-      'metaSuffix': 'workflow',
-      'xmlElement': 'Workflow',
-      'fieldNames': 'fullName'
-    },
-    {
-      'directoryName': 'profiles',
-      'metaSuffix': 'profile',
-      'xmlElement': 'Profile',
-      'fieldNames': 'fullName,application,apexClass,name,externalDataSource,flow,object,apexPage,recordType,tab,field,startAddress,dataCategoryGroup,layout,weekdayStart,friendlyname'
-    },
-    {
-      'directoryName': 'permissionsets',
-      'metaSuffix': 'permissionset',
-      'xmlElement': 'PermissionSet',
-      'fieldNames': 'fullName,application,apexClass,name,externalDataSource,flow,object,apexPage,recordType,tab,field'
-    },
-    {
-      'directoryName': 'matchingRules',
-      'metaSuffix': 'matchingRule',
-      'xmlElement': 'MatchingRules',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'assignmentRules',
-      'metaSuffix': 'assignmentRules',
-      'xmlElement': 'AssignmentRules',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'flows',
-      'metaSuffix': 'flow',
-      'xmlElement': 'Flow',
-      'fieldNames': 'fullName,apexClass,name,object,field,layout,actionName,targetReference,assignToReference,choiceText,promptText'
-    },
-    {
-      'directoryName': 'escalationRules',
-      'metaSuffix': 'escalationRules',
-      'xmlElement': 'EscalationRules',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'sharingRules',
-      'metaSuffix': 'sharingRules',
-      'xmlElement': 'SharingRules',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'autoResponseRules',
-      'metaSuffix': 'autoResponseRules',
-      'xmlElement': 'AutoResponseRules',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'globalValueSetTranslations',
-      'metaSuffix': 'globalValueSetTranslation',
-      'xmlElement': 'GlobalValueSetTranslation',
-      'fieldNames': 'fullName,masterLabel'
-    },
-    {
-      'directoryName': 'standardValueSetTranslations',
-      'metaSuffix': 'standardValueSetTranslation',
-      'xmlElement': 'StandardValueSetTranslation',
-      'fieldNames': 'fullName,masterLabel'
-    },
-    {
-      'directoryName': 'translations',
-      'metaSuffix': 'translation',
-      'xmlElement': 'Translation',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'globalValueSets',
-      'metaSuffix': 'globalValueSet',
-      'xmlElement': 'GlobalValueSet',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'standardValueSets',
-      'metaSuffix': 'standardValueSet',
-      'xmlElement': 'StandardValueSet',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'decisionMatrixDefinition',
-      'metaSuffix': 'decisionMatrixDefinition',
-      'xmlElement': 'DecisionMatrixDefinition',
-      'fieldNames': 'fullName,name'
-    },
-    {
-      'directoryName': 'aiScoringModelDefinitions',
-      'metaSuffix': 'aiScoringModelDefinition',
-      'xmlElement': 'AIScoringModelDefinition',
-      'fieldNames': 'fullName,name'
-    }
+  {
+    directoryName: 'labels',
+    metaSuffix: 'labels',
+    xmlElement: 'CustomLabels',
+    fieldNames: 'fullName',
+  },
+  {
+    directoryName: 'workflows',
+    metaSuffix: 'workflow',
+    xmlElement: 'Workflow',
+    fieldNames: 'fullName',
+  },
+  {
+    directoryName: 'profiles',
+    metaSuffix: 'profile',
+    xmlElement: 'Profile',
+    fieldNames:
+      'fullName,application,apexClass,name,externalDataSource,flow,object,apexPage,recordType,tab,field,startAddress,dataCategoryGroup,layout,weekdayStart,friendlyname',
+  },
+  {
+    directoryName: 'permissionsets',
+    metaSuffix: 'permissionset',
+    xmlElement: 'PermissionSet',
+    fieldNames: 'fullName,application,apexClass,name,externalDataSource,flow,object,apexPage,recordType,tab,field',
+  },
+  {
+    directoryName: 'matchingRules',
+    metaSuffix: 'matchingRule',
+    xmlElement: 'MatchingRules',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'assignmentRules',
+    metaSuffix: 'assignmentRules',
+    xmlElement: 'AssignmentRules',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'flows',
+    metaSuffix: 'flow',
+    xmlElement: 'Flow',
+    fieldNames:
+      'fullName,apexClass,name,object,field,layout,actionName,targetReference,assignToReference,choiceText,promptText',
+  },
+  {
+    directoryName: 'escalationRules',
+    metaSuffix: 'escalationRules',
+    xmlElement: 'EscalationRules',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'sharingRules',
+    metaSuffix: 'sharingRules',
+    xmlElement: 'SharingRules',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'autoResponseRules',
+    metaSuffix: 'autoResponseRules',
+    xmlElement: 'AutoResponseRules',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'globalValueSetTranslations',
+    metaSuffix: 'globalValueSetTranslation',
+    xmlElement: 'GlobalValueSetTranslation',
+    fieldNames: 'fullName,masterLabel',
+  },
+  {
+    directoryName: 'standardValueSetTranslations',
+    metaSuffix: 'standardValueSetTranslation',
+    xmlElement: 'StandardValueSetTranslation',
+    fieldNames: 'fullName,masterLabel',
+  },
+  {
+    directoryName: 'translations',
+    metaSuffix: 'translation',
+    xmlElement: 'Translation',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'globalValueSets',
+    metaSuffix: 'globalValueSet',
+    xmlElement: 'GlobalValueSet',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'standardValueSets',
+    metaSuffix: 'standardValueSet',
+    xmlElement: 'StandardValueSet',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'decisionMatrixDefinition',
+    metaSuffix: 'decisionMatrixDefinition',
+    xmlElement: 'DecisionMatrixDefinition',
+    fieldNames: 'fullName,name',
+  },
+  {
+    directoryName: 'aiScoringModelDefinitions',
+    metaSuffix: 'aiScoringModelDefinition',
+    xmlElement: 'AIScoringModelDefinition',
+    fieldNames: 'fullName,name',
+  },
 ];
 
 export default jsonData;

--- a/src/metadata/metadata.ts
+++ b/src/metadata/metadata.ts
@@ -1,3 +1,5 @@
+'use strict';
+
 import { Metadata } from './metadataInterface.js';
 
 const jsonData: Metadata[] = [

--- a/src/metadata/metadataInterface.ts
+++ b/src/metadata/metadataInterface.ts
@@ -1,0 +1,8 @@
+'use strict';
+
+export interface Metadata {
+  directoryName: string;
+  metaSuffix: string;
+  xmlElement: string;
+  fieldNames: string;
+}

--- a/src/service/composeAndWriteFile.ts
+++ b/src/service/composeAndWriteFile.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+
+import * as fs from 'node:fs';
+import { XML_HEADER, NAMESPACE, INDENT } from '../helpers/constants.js';
+
+export function composeAndWriteFile(combinedXmlContents: string[], filePath: string, xmlElement: string): void {
+  // Combine XML contents into a single string
+  let finalXmlContent = combinedXmlContents.join('\n');
+
+  // Remove duplicate XML declarations
+  finalXmlContent = finalXmlContent.replace(/<\?xml version="1.0" encoding="UTF-8"\?>/g, '');
+
+  // Remove duplicate parent elements
+  finalXmlContent = finalXmlContent.replace(`<${xmlElement}>`, '');
+  finalXmlContent = finalXmlContent.replace(`</${xmlElement}>`, '');
+
+  // Remove extra newlines
+  finalXmlContent = finalXmlContent.replace(/(\n\s*){2,}/g, `\n${INDENT}`);
+
+  fs.writeFileSync(filePath, `${XML_HEADER}\n<${xmlElement} ${NAMESPACE}>${finalXmlContent}</${xmlElement}>`);
+  console.log(`Created composed file: ${filePath}`);
+}

--- a/src/service/composeFileHandler.ts
+++ b/src/service/composeFileHandler.ts
@@ -1,0 +1,62 @@
+/* eslint-disable */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { CUSTOM_LABELS_FILE } from '../helpers/constants.js';
+import { composeAndWriteFile } from '../service/composeAndWriteFile.js';
+
+export function composeFileHandler(metadataPath: string, metaSuffix: string, xmlElement: string): void {
+  const processFilesInDirectory = (dirPath: string): string[] => {
+    const combinedXmlContents: string[] = [];
+    const files = fs.readdirSync(dirPath);
+
+    // Sort files based on the name
+    files.sort((fileA, fileB) => {
+      const fullNameA = fileA.split('.')[0].toLowerCase();
+      const fullNameB = fileB.split('.')[0].toLowerCase();
+      return fullNameA.localeCompare(fullNameB);
+    });
+
+    files.forEach((file) => {
+      const filePath = path.join(dirPath, file);
+
+      if (fs.statSync(filePath).isFile()) {
+        if (metaSuffix === 'labels' && !file.endsWith(`label-meta.xml`)) {
+          return; // Skip files that don't match the expected naming convention for custom labels
+        }
+
+        const xmlContent = fs.readFileSync(filePath, 'utf-8');
+        combinedXmlContents.push(xmlContent);
+      } else if (fs.statSync(filePath).isDirectory()) {
+        const subdirectoryContents = processFilesInDirectory(filePath);
+        combinedXmlContents.push(...subdirectoryContents); // Concatenate contents from subdirectories
+      }
+    });
+
+    return combinedXmlContents;
+  };
+
+  // Process labels in root metadata folder
+  // Process other metadata files in subdirectories
+  if (metaSuffix === 'labels') {
+    const combinedXmlContents: string[] = processFilesInDirectory(metadataPath);
+    const filePath = path.join(metadataPath, CUSTOM_LABELS_FILE);
+
+    composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
+  } else {
+    const subdirectories = fs
+      .readdirSync(metadataPath)
+      .map((file) => path.join(metadataPath, file))
+      .filter((filePath) => fs.statSync(filePath).isDirectory());
+
+    subdirectories.forEach((subdirectory) => {
+      console.log('Processing subdirectory:', subdirectory);
+      const combinedXmlContents: string[] = processFilesInDirectory(subdirectory);
+      const subdirectoryBasename = path.basename(subdirectory);
+      const filePath = path.join(metadataPath, `${subdirectoryBasename}.${metaSuffix}-meta.xml`);
+
+      composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
+    });
+  }
+}

--- a/src/service/decomposeFileHandler.ts
+++ b/src/service/decomposeFileHandler.ts
@@ -1,0 +1,26 @@
+/* eslint-disable */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { INDENT } from '../helpers/constants.js';
+import { xml2jsParser } from './xml2jsParser.js';
+
+export function decomposeFileHandler(
+  metadataPath: string,
+  metaSuffix: string,
+  fieldNames: string,
+  xmlElement: string
+): void {
+  const files = fs.readdirSync(metadataPath);
+  files.forEach((file) => {
+    const filePath = path.join(metadataPath, file);
+    if (file.endsWith(`.${metaSuffix}-meta.xml`)) {
+      console.log(`Parsing metadata file: ${filePath}`);
+      const xmlContent = fs.readFileSync(filePath, 'utf-8');
+      const baseName = path.basename(filePath, `.${metaSuffix}-meta.xml`);
+      const outputPath = path.join(metadataPath, metaSuffix === 'labels' ? '' : baseName);
+      xml2jsParser(xmlContent, outputPath, fieldNames, xmlElement, baseName, metaSuffix, INDENT);
+    }
+  });
+}

--- a/src/service/findFieldName.ts
+++ b/src/service/findFieldName.ts
@@ -1,0 +1,24 @@
+/* eslint-disable */
+
+export function findFieldName(element: any, fieldNames: string): string | undefined {
+  const fieldNamesArray = fieldNames.split(',');
+
+  for (const fieldName of fieldNamesArray) {
+    // Check if the current fieldName exists in the element
+    if (element[fieldName]) {
+      return element[fieldName];
+    }
+  }
+
+  // Iterate through child elements to find the field name
+  for (const key in element) {
+    if (typeof element[key] === 'object') {
+      const childFieldName = findFieldName(element[key], fieldNames);
+      if (childFieldName) {
+        return childFieldName;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/src/service/getAttributesForMetadataType.ts
+++ b/src/service/getAttributesForMetadataType.ts
@@ -2,11 +2,32 @@
 
 import { Metadata } from '../metadata/metadataInterface.js';
 
-export function getAttributesForMetadataType(jsonData: Metadata[], metadataType: string): Metadata | null {
+export function getAttributesForMetadataType(
+  jsonData: Metadata[],
+  metadataType: string,
+  dxDirectory: string
+): {
+  metaSuffix: string;
+  fieldNames: string;
+  xmlElement: string;
+  metadataPath: string;
+} | null {
   const metadata = jsonData.find((item) => item.metaSuffix === metadataType);
 
   if (metadata) {
-    return metadata;
+    const metaSuffix = metadata.metaSuffix;
+    const directoryName = metadata.directoryName || '';
+    const fieldNames = metadata.fieldNames;
+    const xmlElement = metadata.xmlElement;
+    const metadataPath = `${dxDirectory}/${directoryName}`;
+
+    return {
+      metaSuffix,
+      fieldNames,
+      xmlElement,
+      metadataPath,
+    };
   }
+
   return null;
 }

--- a/src/service/getAttributesForMetadataType.ts
+++ b/src/service/getAttributesForMetadataType.ts
@@ -1,0 +1,12 @@
+'use strict';
+
+import { Metadata } from '../metadata/metadataInterface.js';
+
+export function getAttributesForMetadataType(jsonData: Metadata[], metadataType: string): Metadata | null {
+  const metadata = jsonData.find((item) => item.metaSuffix === metadataType);
+
+  if (metadata) {
+    return metadata;
+  }
+  return null;
+}

--- a/src/service/printChildElements.ts
+++ b/src/service/printChildElements.ts
@@ -4,7 +4,7 @@ export function printChildElements(
   element: any,
   parentKey: string | null = null,
   xmlContent: string,
-  indent: string = '    '
+  indent: string
 ): string {
   // Recursive function to handle nested elements
   function processElement(element: any, parentKey: string | null = null, currentIndent: string = ''): void {

--- a/src/service/printChildElements.ts
+++ b/src/service/printChildElements.ts
@@ -1,0 +1,50 @@
+/* eslint-disable */
+
+export function printChildElements(
+  element: any,
+  parentKey: string | null = null,
+  xmlContent: string,
+  indent: string = '    '
+): string {
+  // Recursive function to handle nested elements
+  function processElement(element: any, parentKey: string | null = null, currentIndent: string = ''): void {
+    if (typeof element === 'object') {
+      if (parentKey) {
+        xmlContent += `${currentIndent}<${parentKey}>\n`;
+      }
+
+      Object.entries(element).forEach(([key, value]) => {
+        if (key === '$') {
+          // Skip the special key representing attributes, like the namespace
+          return;
+        }
+
+        if (Array.isArray(value)) {
+          // Handle arrays of elements
+          value.forEach((arrayElement) => {
+            if (typeof arrayElement === 'object') {
+              processElement(arrayElement, key, `${currentIndent}${indent}`);
+            } else {
+              xmlContent += `${currentIndent}${indent}<${key}>${arrayElement}</${key}>\n`;
+            }
+          });
+        } else if (typeof value === 'object') {
+          // Recursively handle nested objects
+          processElement(value, key, `${currentIndent}${indent}`);
+        } else {
+          // Print regular key-value pairs
+          xmlContent += `${currentIndent}${indent}<${key}>${value}</${key}>\n`;
+        }
+      });
+
+      if (parentKey) {
+        xmlContent += `${currentIndent}</${parentKey}>\n`;
+      }
+    }
+  }
+
+  // Start processing with the initial indentation
+  processElement(element, parentKey, indent);
+
+  return xmlContent;
+}

--- a/src/service/printChildElements.ts
+++ b/src/service/printChildElements.ts
@@ -1,50 +1,27 @@
 /* eslint-disable */
 
-export function printChildElements(
-  element: any,
-  parentKey: string | null = null,
-  xmlContent: string,
-  indent: string
-): string {
-  // Recursive function to handle nested elements
-  function processElement(element: any, parentKey: string | null = null, currentIndent: string = ''): void {
-    if (typeof element === 'object') {
-      if (parentKey) {
-        xmlContent += `${currentIndent}<${parentKey}>\n`;
-      }
+import { XMLBuilder } from 'fast-xml-parser';
+import { INDENT } from '../helpers/constants.js';
+import { XML_PARSER_OPTION } from '../types/xmlParserOptions.js';
 
-      Object.entries(element).forEach(([key, value]) => {
-        if (key === '$') {
-          // Skip the special key representing attributes, like the namespace
-          return;
-        }
+export function printChildElements(element: any, indentLevel: number = 2): string {
+  const JSON_PARSER_OPTION = {
+    ...XML_PARSER_OPTION,
+    format: true,
+    indentBy: INDENT,
+    suppressBooleanAttributes: false,
+    suppressEmptyNode: false,
+  };
 
-        if (Array.isArray(value)) {
-          // Handle arrays of elements
-          value.forEach((arrayElement) => {
-            if (typeof arrayElement === 'object') {
-              processElement(arrayElement, key, `${currentIndent}${indent}`);
-            } else {
-              xmlContent += `${currentIndent}${indent}<${key}>${arrayElement}</${key}>\n`;
-            }
-          });
-        } else if (typeof value === 'object') {
-          // Recursively handle nested objects
-          processElement(value, key, `${currentIndent}${indent}`);
-        } else {
-          // Print regular key-value pairs
-          xmlContent += `${currentIndent}${indent}<${key}>${value}</${key}>\n`;
-        }
-      });
+  const xmlBuilder = new XMLBuilder(JSON_PARSER_OPTION);
+  const xmlString = xmlBuilder.build(element);
 
-      if (parentKey) {
-        xmlContent += `${currentIndent}</${parentKey}>\n`;
-      }
-    }
-  }
+  // Manually format the XML string with the desired indentation
+  const formattedXml = xmlString
+    .split('\n')
+    .map((line: string) => `${' '.repeat(indentLevel * INDENT.length)}${line}`)
+    .join('\n')
+    .trimEnd();
 
-  // Start processing with the initial indentation
-  processElement(element, parentKey, indent);
-
-  return xmlContent;
+  return formattedXml;
 }

--- a/src/service/printChildElements.ts
+++ b/src/service/printChildElements.ts
@@ -2,17 +2,9 @@
 
 import { XMLBuilder } from 'fast-xml-parser';
 import { INDENT } from '../helpers/constants.js';
-import { XML_PARSER_OPTION } from '../types/xmlParserOptions.js';
+import { JSON_PARSER_OPTION } from '../types/jsonParserOptions.js';
 
 export function printChildElements(element: any, indentLevel: number = 2): string {
-  const JSON_PARSER_OPTION = {
-    ...XML_PARSER_OPTION,
-    format: true,
-    indentBy: INDENT,
-    suppressBooleanAttributes: false,
-    suppressEmptyNode: false,
-  };
-
   const xmlBuilder = new XMLBuilder(JSON_PARSER_OPTION);
   const xmlString = xmlBuilder.build(element);
 

--- a/src/service/xml2jsParser.ts
+++ b/src/service/xml2jsParser.ts
@@ -1,0 +1,104 @@
+/* eslint-disable */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { XMLParser } from 'fast-xml-parser';
+
+import { XML_PARSER_OPTION } from '../types/xmlParserOptions.js';
+import { XML_HEADER } from '../helpers/constants.js';
+import { findFieldName } from './findFieldName.js';
+import { printChildElements } from './printChildElements.js';
+
+export function xml2jsParser(
+  xmlString: string,
+  metadataPath: string,
+  fieldNames: string,
+  xmlElement: string,
+  baseName: string,
+  metaSuffix: string,
+  indent: string = '    '
+): void {
+  try {
+    const xmlParser = new XMLParser(XML_PARSER_OPTION);
+    const result = xmlParser.parse(xmlString);
+
+    const rootElementName = Object.keys(result)[1];
+    const rootElement = result[rootElementName];
+    let leafContent = '';
+    let leafCount = 0;
+
+    // Iterate through child elements to find the field name for each
+    Object.keys(rootElement)
+      .filter((key: string) => !key.startsWith('@'))
+      .forEach((key: string) => {
+        if (Array.isArray(rootElement[key])) {
+          // Iterate through the elements of the array
+          for (const element of rootElement[key]) {
+            let elementContent = '';
+            elementContent += `${XML_HEADER}\n`;
+
+            const fieldName = findFieldName(element, fieldNames);
+            const outputDirectory = path.join(metadataPath, metaSuffix === 'labels' ? '' : key);
+            const outputFileName: string = `${fieldName}.${metaSuffix === 'labels' ? key.slice(0, -1) : key}-meta.xml`;
+            const outputPath = path.join(outputDirectory, outputFileName);
+
+            // Create the output directory if it doesn't exist
+            fs.mkdirSync(outputDirectory, { recursive: true });
+
+            // Call the printChildElements to build the XML content string
+            elementContent = printChildElements(element, key, elementContent);
+
+            // Write the XML content to the determined output path
+            fs.writeFileSync(outputPath, elementContent);
+
+            console.log(`XML content saved to: ${outputPath}`);
+          }
+        } else if (typeof rootElement[key] === 'object') {
+          let elementContent = '';
+          elementContent += `${XML_HEADER}\n`;
+
+          const fieldName = findFieldName(rootElement[key], fieldNames);
+
+          const outputDirectory = path.join(metadataPath, key);
+          const outputFileName: string = `${fieldName}.${metaSuffix === 'labels' ? key.slice(0, -1) : key}-meta.xml`;
+          const outputPath = path.join(outputDirectory, outputFileName);
+
+          // Create the output directory if it doesn't exist
+          fs.mkdirSync(outputDirectory, { recursive: true });
+
+          // Call the printChildElements to build the XML content string
+          elementContent = printChildElements(rootElement[key], key, elementContent);
+
+          // Write the XML content to the determined output path
+          fs.writeFileSync(outputPath, elementContent);
+
+          console.log(`XML content saved to: ${outputPath}`);
+        } else {
+          // Process XML elements that do not have children (e.g., leaf elements)
+          const fieldValue = rootElement[key];
+          // Append leaf element to the accumulated XML content
+          leafContent += `${indent}<${key}>${fieldValue}</${key}>\n`;
+          leafCount++;
+        }
+      });
+
+    if (leafCount > 0) {
+      let leafFile = `${XML_HEADER}\n`;
+      leafFile += `<${xmlElement}>\n`;
+
+      const sortedLeafContent = leafContent
+        .split('\n') // Split by lines
+        .filter((line) => line.trim() !== '') // Remove empty lines
+        .sort() // Sort alphabetically
+        .join('\n'); // Join back into a string
+      leafFile += sortedLeafContent;
+      leafFile += `\n</${xmlElement}>`;
+      const leafOutputPath = path.join(metadataPath, `${baseName}.${metaSuffix}-meta.xml`);
+      fs.writeFileSync(leafOutputPath, leafFile);
+
+      console.log(`All leaf elements saved to: ${leafOutputPath}`);
+    }
+  } catch (err) {
+    console.error('Error parsing XML:', err);
+  }
+}

--- a/src/service/xml2jsParser.ts
+++ b/src/service/xml2jsParser.ts
@@ -46,10 +46,14 @@ export function xml2jsParser(
             fs.mkdirSync(outputDirectory, { recursive: true });
 
             // Call the printChildElements to build the XML content string
-            elementContent = printChildElements(element, key, elementContent, indent);
+            elementContent = printChildElements(element);
+            let decomposeFileContents = `${XML_HEADER}\n`;
+            decomposeFileContents += `${indent}<${key}>\n`;
+            decomposeFileContents += `${elementContent}\n`;
+            decomposeFileContents += `${indent}</${key}>\n`;
 
             // Write the XML content to the determined output path
-            fs.writeFileSync(outputPath, elementContent);
+            fs.writeFileSync(outputPath, decomposeFileContents);
 
             console.log(`XML content saved to: ${outputPath}`);
           }
@@ -67,10 +71,14 @@ export function xml2jsParser(
           fs.mkdirSync(outputDirectory, { recursive: true });
 
           // Call the printChildElements to build the XML content string
-          elementContent = printChildElements(rootElement[key], key, elementContent, indent);
+          elementContent = printChildElements(rootElement[key]);
+          let decomposeFileContents = `${XML_HEADER}\n`;
+          decomposeFileContents += `${indent}<${key}>\n`;
+          decomposeFileContents += `${elementContent}\n`;
+          decomposeFileContents += `${indent}</${key}>\n`;
 
           // Write the XML content to the determined output path
-          fs.writeFileSync(outputPath, elementContent);
+          fs.writeFileSync(outputPath, decomposeFileContents);
 
           console.log(`XML content saved to: ${outputPath}`);
         } else {

--- a/src/service/xml2jsParser.ts
+++ b/src/service/xml2jsParser.ts
@@ -16,7 +16,7 @@ export function xml2jsParser(
   xmlElement: string,
   baseName: string,
   metaSuffix: string,
-  indent: string = '    '
+  indent: string
 ): void {
   try {
     const xmlParser = new XMLParser(XML_PARSER_OPTION);
@@ -46,7 +46,7 @@ export function xml2jsParser(
             fs.mkdirSync(outputDirectory, { recursive: true });
 
             // Call the printChildElements to build the XML content string
-            elementContent = printChildElements(element, key, elementContent);
+            elementContent = printChildElements(element, key, elementContent, indent);
 
             // Write the XML content to the determined output path
             fs.writeFileSync(outputPath, elementContent);
@@ -67,7 +67,7 @@ export function xml2jsParser(
           fs.mkdirSync(outputDirectory, { recursive: true });
 
           // Call the printChildElements to build the XML content string
-          elementContent = printChildElements(rootElement[key], key, elementContent);
+          elementContent = printChildElements(rootElement[key], key, elementContent, indent);
 
           // Write the XML content to the determined output path
           fs.writeFileSync(outputPath, elementContent);

--- a/src/service/xml2jsParser.ts
+++ b/src/service/xml2jsParser.ts
@@ -34,53 +34,10 @@ export function xml2jsParser(
         if (Array.isArray(rootElement[key])) {
           // Iterate through the elements of the array
           for (const element of rootElement[key]) {
-            let elementContent = '';
-            elementContent += `${XML_HEADER}\n`;
-
-            const fieldName = findFieldName(element, fieldNames);
-            const outputDirectory = path.join(metadataPath, metaSuffix === 'labels' ? '' : key);
-            const outputFileName: string = `${fieldName}.${metaSuffix === 'labels' ? key.slice(0, -1) : key}-meta.xml`;
-            const outputPath = path.join(outputDirectory, outputFileName);
-
-            // Create the output directory if it doesn't exist
-            fs.mkdirSync(outputDirectory, { recursive: true });
-
-            // Call the printChildElements to build the XML content string
-            elementContent = printChildElements(element);
-            let decomposeFileContents = `${XML_HEADER}\n`;
-            decomposeFileContents += `${indent}<${key}>\n`;
-            decomposeFileContents += `${elementContent}\n`;
-            decomposeFileContents += `${indent}</${key}>\n`;
-
-            // Write the XML content to the determined output path
-            fs.writeFileSync(outputPath, decomposeFileContents);
-
-            console.log(`XML content saved to: ${outputPath}`);
+            buildNestedFile(element, metadataPath, metaSuffix, fieldNames, key, indent);
           }
         } else if (typeof rootElement[key] === 'object') {
-          let elementContent = '';
-          elementContent += `${XML_HEADER}\n`;
-
-          const fieldName = findFieldName(rootElement[key], fieldNames);
-
-          const outputDirectory = path.join(metadataPath, key);
-          const outputFileName: string = `${fieldName}.${metaSuffix === 'labels' ? key.slice(0, -1) : key}-meta.xml`;
-          const outputPath = path.join(outputDirectory, outputFileName);
-
-          // Create the output directory if it doesn't exist
-          fs.mkdirSync(outputDirectory, { recursive: true });
-
-          // Call the printChildElements to build the XML content string
-          elementContent = printChildElements(rootElement[key]);
-          let decomposeFileContents = `${XML_HEADER}\n`;
-          decomposeFileContents += `${indent}<${key}>\n`;
-          decomposeFileContents += `${elementContent}\n`;
-          decomposeFileContents += `${indent}</${key}>\n`;
-
-          // Write the XML content to the determined output path
-          fs.writeFileSync(outputPath, decomposeFileContents);
-
-          console.log(`XML content saved to: ${outputPath}`);
+          buildNestedFile(rootElement[key], metadataPath, metaSuffix, fieldNames, key, indent);
         } else {
           // Process XML elements that do not have children (e.g., leaf elements)
           const fieldValue = rootElement[key];
@@ -109,4 +66,38 @@ export function xml2jsParser(
   } catch (err) {
     console.error('Error parsing XML:', err);
   }
+}
+
+function buildNestedFile(
+  element: any,
+  metadataPath: string,
+  metaSuffix: string,
+  fieldNames: string,
+  parentKey: string,
+  indent: string
+) {
+  let elementContent = '';
+  elementContent += `${XML_HEADER}\n`;
+
+  const fieldName = findFieldName(element, fieldNames);
+
+  const outputDirectory = path.join(metadataPath, parentKey);
+  const outputFileName: string = `${fieldName}.${
+    metaSuffix === 'labels' ? parentKey.slice(0, -1) : parentKey
+  }-meta.xml`;
+  const outputPath = path.join(outputDirectory, outputFileName);
+
+  // Create the output directory if it doesn't exist
+  fs.mkdirSync(outputDirectory, { recursive: true });
+
+  // Call the printChildElements to build the XML content string
+  elementContent = printChildElements(element);
+  let decomposeFileContents = `${XML_HEADER}\n`;
+  decomposeFileContents += `${indent}<${parentKey}>\n`;
+  decomposeFileContents += `${elementContent}\n`;
+  decomposeFileContents += `${indent}</${parentKey}>\n`;
+
+  // Write the XML content to the determined output path
+  fs.writeFileSync(outputPath, decomposeFileContents);
+  console.log(`XML content saved to: ${outputPath}`);
 }

--- a/src/types/jsonParserOptions.ts
+++ b/src/types/jsonParserOptions.ts
@@ -1,0 +1,12 @@
+'use strict';
+
+import { INDENT } from '../helpers/constants.js';
+import { XML_PARSER_OPTION } from './xmlParserOptions.js';
+
+export const JSON_PARSER_OPTION = {
+  ...XML_PARSER_OPTION,
+  format: true,
+  indentBy: INDENT,
+  suppressBooleanAttributes: false,
+  suppressEmptyNode: false,
+};

--- a/src/types/xmlParserOptions.ts
+++ b/src/types/xmlParserOptions.ts
@@ -1,0 +1,12 @@
+'use strict';
+
+export const XML_PARSER_OPTION = {
+  commentPropName: '#comment',
+  ignoreAttributes: false,
+  ignoreNameSpace: false,
+  parseTagValue: false,
+  parseNodeValue: false,
+  parseAttributeValue: false,
+  trimValues: true,
+  processEntities: false,
+};


### PR DESCRIPTION
Per @scolladon's suggestion, refactor the code to move functions to separate files.

@scolladon - Can you review this request when you have a moment please?

This is testing SAT right now. I think the `src/service/xml2jsParser.ts` function probably can be broken up more, but I think we can tackle that after this is merged into `beta`.

The `build` job @AllanOricil added is passing as well which runs the current tests (thank you Alan!).