### PR TITLE
refactor: use async await `fs` API

### DIFF
--- a/src/commands/decomposer/compose.ts
+++ b/src/commands/decomposer/compose.ts
@@ -46,7 +46,7 @@ export default class DecomposerCompose extends SfCommand<DecomposerComposeResult
 
     if (metaAttributes) {
       const { metaSuffix, xmlElement, metadataPath } = metaAttributes;
-      composeFileHandler(metadataPath, metaSuffix, xmlElement);
+      await composeFileHandler(metadataPath, metaSuffix, xmlElement);
       this.log(`All metadata files have been composed for the metadata type: ${metaSuffix}`);
     } else {
       this.error(`Metadata type ${metadataTypeToRetrieve} not found.`);

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -46,7 +46,7 @@ export default class DecomposerDecompose extends SfCommand<DecomposerDecomposeRe
 
     if (metaAttributes) {
       const { metaSuffix, fieldNames, xmlElement, metadataPath, recurse } = metaAttributes;
-      decomposeFileHandler(metadataPath, metaSuffix, fieldNames, xmlElement, recurse);
+      await decomposeFileHandler(metadataPath, metaSuffix, fieldNames, xmlElement, recurse);
       this.log(`All metadata files have been decomposed for the metadata type: ${metaSuffix}`);
     } else {
       this.error(`Metadata type ${metadataTypeToRetrieve} not found.`);

--- a/src/service/composeAndWriteFile.ts
+++ b/src/service/composeAndWriteFile.ts
@@ -1,9 +1,13 @@
 'use strict';
 
-import * as fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 import { XML_HEADER, NAMESPACE, INDENT } from '../helpers/constants.js';
 
-export function composeAndWriteFile(combinedXmlContents: string[], filePath: string, xmlElement: string): void {
+export async function composeAndWriteFile(
+  combinedXmlContents: string[],
+  filePath: string,
+  xmlElement: string
+): Promise<void> {
   // Combine XML contents into a single string
   let finalXmlContent = combinedXmlContents.join('\n');
 
@@ -17,6 +21,6 @@ export function composeAndWriteFile(combinedXmlContents: string[], filePath: str
   // Remove extra newlines
   finalXmlContent = finalXmlContent.replace(/(\n\s*){2,}/g, `\n${INDENT}`);
 
-  fs.writeFileSync(filePath, `${XML_HEADER}\n<${xmlElement} ${NAMESPACE}>${finalXmlContent}</${xmlElement}>`);
+  await fs.writeFile(filePath, `${XML_HEADER}\n<${xmlElement} ${NAMESPACE}>${finalXmlContent}</${xmlElement}>`);
   // console.log(`Created composed file: ${filePath}`);
 }

--- a/src/service/composeFileHandler.ts
+++ b/src/service/composeFileHandler.ts
@@ -1,99 +1,85 @@
 'use strict';
+/* eslint-disable no-await-in-loop */
 
-import * as fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { CUSTOM_LABELS_FILE } from '../helpers/constants.js';
 import { composeAndWriteFile } from '../service/composeAndWriteFile.js';
+const processFilesInDirectory = async (dirPath: string, metaSuffix: string): Promise<string[]> => {
+  const combinedXmlContents: string[] = [];
+  const files = await fs.readdir(dirPath);
 
-export function composeFileHandler(metadataPath: string, metaSuffix: string, xmlElement: string): void {
-  const processFilesInDirectory = (dirPath: string): string[] => {
-    const combinedXmlContents: string[] = [];
-    const files = fs.readdirSync(dirPath);
+  // Sort files based on the name
+  files.sort((fileA, fileB) => {
+    const fullNameA = fileA.split('.')[0].toLowerCase();
+    const fullNameB = fileB.split('.')[0].toLowerCase();
+    return fullNameA.localeCompare(fullNameB);
+  });
 
-    // Sort files based on the name
-    files.sort((fileA, fileB) => {
-      const fullNameA = fileA.split('.')[0].toLowerCase();
-      const fullNameB = fileB.split('.')[0].toLowerCase();
-      return fullNameA.localeCompare(fullNameB);
-    });
+  for (const file of files) {
+    const filePath = path.join(dirPath, file);
+    const fileStat = await fs.stat(filePath);
+    if ((fileStat.isFile() && metaSuffix !== 'labels') || file.endsWith('label-meta.xml')) {
+      const xmlContent = await fs.readFile(filePath, 'utf-8');
+      combinedXmlContents.push(xmlContent);
+    } else if (fileStat.isDirectory()) {
+      const subdirectoryContents = await processFilesInDirectory(filePath, metaSuffix);
+      combinedXmlContents.push(...subdirectoryContents); // Concatenate contents from subdirectories
+    }
+  }
 
-    files.forEach((file) => {
-      const filePath = path.join(dirPath, file);
-      if (fs.statSync(filePath).isFile()) {
-        if (metaSuffix === 'labels' && !file.endsWith('label-meta.xml')) {
-          return; // Skip files that don't match the expected naming convention for custom labels
-        }
+  return combinedXmlContents;
+};
 
-        const xmlContent = fs.readFileSync(filePath, 'utf-8');
-        combinedXmlContents.push(xmlContent);
-      } else if (fs.statSync(filePath).isDirectory()) {
-        const subdirectoryContents = processFilesInDirectory(filePath);
-        combinedXmlContents.push(...subdirectoryContents); // Concatenate contents from subdirectories
-      }
-    });
-
-    return combinedXmlContents;
-  };
-
+export async function composeFileHandler(metadataPath: string, metaSuffix: string, xmlElement: string): Promise<void> {
   // Process labels in root metadata folder
   // Process other metadata files in subdirectories
   if (metaSuffix === 'labels') {
-    const combinedXmlContents: string[] = processFilesInDirectory(metadataPath);
+    const combinedXmlContents: string[] = await processFilesInDirectory(metadataPath, metaSuffix);
     const filePath = path.join(metadataPath, CUSTOM_LABELS_FILE);
 
-    composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
+    await composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
   } else if (metaSuffix === 'bot' || metaSuffix === 'botVersion') {
-    const botDirectories = fs
-      .readdirSync(metadataPath)
-      .map((file) => path.join(metadataPath, file))
-      .filter((filePath) => fs.statSync(filePath).isDirectory());
+    const botDirectories = (await fs.readdir(metadataPath)).map((file) => path.join(metadataPath, file));
 
-    botDirectories.forEach((botDirectory) => {
-      const subdirectories = fs
-        .readdirSync(botDirectory)
-        .map((file) => path.join(botDirectory, file))
-        .filter((filePath) => {
-          const isDirectory = fs.statSync(filePath).isDirectory();
+    for (const botDirectory of botDirectories) {
+      const botDirStat = await fs.stat(botDirectory);
+      if (botDirStat.isDirectory()) {
+        const subdirectories = (await fs.readdir(botDirectory)).map((file) => path.join(botDirectory, file));
 
-          if (isDirectory) {
-            if (metaSuffix === 'botVersion') {
-              // Scan sub-directories that have 'v#' regex
-              return /v\d+/.test(path.basename(filePath));
-            } else if (metaSuffix === 'bot') {
-              // Scan sub-directories that do NOT have 'v#' regex
-              return !/v\d+/.test(path.basename(filePath));
-            }
+        for (const subdirectory of subdirectories) {
+          const subDirStat = await fs.stat(subdirectory);
+          if (
+            subDirStat.isDirectory() &&
+            ((metaSuffix === 'botVersion' && /v\d+/.test(path.basename(subdirectory))) ||
+              (metaSuffix === 'bot' && !/v\d+/.test(path.basename(subdirectory))))
+          ) {
+            // Process each sub-subdirectory
+            const combinedXmlContents: string[] = await processFilesInDirectory(subdirectory, metaSuffix);
+            const subdirectoryBasename = path.basename(subdirectory);
+            const filePath = path.join(
+              metadataPath,
+              path.basename(botDirectory),
+              `${subdirectoryBasename}.${metaSuffix}-meta.xml`
+            );
+            await composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
           }
-
-          return false; // Default case, not a directory or doesn't match conditions
-        });
-
-      subdirectories.forEach((subdirectory) => {
-        // Process each sub-subdirectory
-        const combinedXmlContents: string[] = processFilesInDirectory(subdirectory);
-        const subdirectoryBasename = path.basename(subdirectory);
-        const filePath = path.join(
-          metadataPath,
-          path.basename(botDirectory),
-          `${subdirectoryBasename}.${metaSuffix}-meta.xml`
-        );
-        composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
-      });
-    });
+        }
+      }
+    }
   } else {
-    const subdirectories = fs
-      .readdirSync(metadataPath)
-      .map((file) => path.join(metadataPath, file))
-      .filter((filePath) => fs.statSync(filePath).isDirectory());
+    const subdirectories = (await fs.readdir(metadataPath)).map((file) => path.join(metadataPath, file));
 
-    subdirectories.forEach((subdirectory) => {
-      // console.log('Processing subdirectory:', subdirectory);
-      const combinedXmlContents: string[] = processFilesInDirectory(subdirectory);
-      const subdirectoryBasename = path.basename(subdirectory);
-      const filePath = path.join(metadataPath, `${subdirectoryBasename}.${metaSuffix}-meta.xml`);
+    for (const subdirectory of subdirectories) {
+      const subDirStat = await fs.stat(subdirectory);
+      if (subDirStat.isDirectory()) {
+        const combinedXmlContents: string[] = await processFilesInDirectory(subdirectory, metaSuffix);
+        const subdirectoryBasename = path.basename(subdirectory);
+        const filePath = path.join(metadataPath, `${subdirectoryBasename}.${metaSuffix}-meta.xml`);
 
-      composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
-    });
+        await composeAndWriteFile(combinedXmlContents, filePath, xmlElement);
+      }
+    }
   }
 }

--- a/src/service/decomposeFileHandler.ts
+++ b/src/service/decomposeFileHandler.ts
@@ -1,46 +1,47 @@
 'use strict';
+/* eslint-disable no-await-in-loop */
 
-import * as fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { INDENT } from '../helpers/constants.js';
 import { xml2jsParser } from './xml2jsParser.js';
 
-export function decomposeFileHandler(
+export async function decomposeFileHandler(
   metadataPath: string,
   metaSuffix: string,
   fieldNames: string,
   xmlElement: string,
   recurse: boolean = false
-): void {
-  const files = fs.readdirSync(metadataPath);
-  files.forEach((file) => {
+): Promise<void> {
+  const files = await fs.readdir(metadataPath);
+  for (const file of files) {
     const filePath = path.join(metadataPath, file);
     if (recurse) {
       // If recurse is true and the current file is a directory, iterate through it
-      const subFiles = fs.readdirSync(filePath);
-      subFiles.forEach((subFile) => {
+      const subFiles = await fs.readdir(filePath);
+      for (const subFile of subFiles) {
         const subFilePath = path.join(filePath, subFile);
-        processFile(metadataPath, subFilePath, metaSuffix, fieldNames, xmlElement, recurse);
-      });
+        await processFile(metadataPath, subFilePath, metaSuffix, fieldNames, xmlElement, recurse);
+      }
     } else {
       // If not recursing or the current file is not a directory, process the file
-      processFile(metadataPath, filePath, metaSuffix, fieldNames, xmlElement);
+      await processFile(metadataPath, filePath, metaSuffix, fieldNames, xmlElement);
     }
-  });
+  }
 }
 
-function processFile(
+async function processFile(
   metadataPath: string,
   filePath: string,
   metaSuffix: string,
   fieldNames: string,
   xmlElement: string,
   recurse: boolean = false
-): void {
+): Promise<void> {
   if (filePath.endsWith(`.${metaSuffix}-meta.xml`)) {
     // console.log(`Parsing metadata file: ${filePath}`);
-    const xmlContent = fs.readFileSync(filePath, 'utf-8');
+    const xmlContent = await fs.readFile(filePath, 'utf-8');
     const baseName = path.basename(filePath, `.${metaSuffix}-meta.xml`);
 
     let outputPath;


### PR DESCRIPTION
Goal of this PR is to switch from 'sync' implementation to 'async' without changing the code too much.

After this refactoring it will be easier to implement a concurrency manager to control the parallelism throughput.
It will help to avoid treat in serial everything (like now).
It will also help to avoid treat everything in parallel (`Promise.all`) and lock CPU or IO operation or event loop.