### PR TITLE
Fix sorting in recomposed files in linux

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     open-pull-requests-limit: 5
     pull-request-branch-name:
       separator: '-'
+    target-branch: 'beta'
     commit-message:
       # cause a release for non-dev-deps
       prefix: fix(deps)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches-ignore:
       - main
+      - beta
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - beta
 
 jobs:
   release:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,10 @@
 {
   "branches": [
-    "main"
+    "main",
+    {
+      "name": "beta",
+      "prerelease": true
+    }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.0.2-beta.1](https://github.com/mcarvin8/sfdx-decomposer-plugin/compare/v3.0.1...v3.0.2-beta.1) (2024-03-07)
+
+### Bug Fixes
+
+- upgrade xml-disassembler to ensure consistent sorting in recomposed files on linux ([4230f95](https://github.com/mcarvin8/sfdx-decomposer-plugin/commit/4230f955b18bf5f50d861ade67b82d2e336b0d22))
+
 ## [3.0.1](https://github.com/mcarvin8/sfdx-decomposer-plugin/compare/v3.0.0...v3.0.1) (2024-02-24)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -185,5 +185,12 @@
   },
   "exports": "./lib/index.js",
   "type": "module",
-  "author": "Matt Carvin"
+  "author": "Matt Carvin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mcarvin8/sfdx-decomposer-plugin.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mcarvin8/sfdx-decomposer-plugin/issues"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@salesforce/sf-plugins-core": "^7.1.9",
     "@salesforce/source-deploy-retrieve": "^10.3.1",
     "fs-extra": "^11.2.0",
-    "xml-disassembler": "^1.0.10-beta.1"
+    "xml-disassembler": "^1.0.10"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.6.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfdx-decomposer",
   "description": "Decomposes Salesforce metadata into more manageable files.",
-  "version": "3.0.1",
+  "version": "3.0.2-beta.1",
   "dependencies": {
     "@oclif/core": "^3.18.1",
     "@salesforce/core": "^6.5.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@salesforce/sf-plugins-core": "^7.1.9",
     "@salesforce/source-deploy-retrieve": "^10.3.1",
     "fs-extra": "^11.2.0",
-    "xml-disassembler": "^1.0.6"
+    "xml-disassembler": "^1.0.10-beta.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.6.1",
@@ -24,7 +24,6 @@
     "@semantic-release/release-notes-generator": "^12.1.0",
     "@types/fs-extra": "^11.0.4",
     "eslint-plugin-sf-plugin": "^1.17.3",
-    "fast-xml-parser": "^4.3.4",
     "husky": "^9.0.6",
     "oclif": "^4.4.10",
     "semantic-release": "^17.4.7",

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -75,10 +75,7 @@ export default class DecomposerDecompose extends SfCommand<DecomposerDecomposeRe
         metaSuffix: metadataTypeEntry.suffix as string,
         strictDirectoryName: metadataTypeEntry.strictDirectoryName as boolean,
         folderType: metadataTypeEntry.folderType as string,
-        metadataPath:
-          metadataTypeToRetrieve === 'botVersion'
-            ? `${dxDirectory}/bots` // Change the directoryName to 'bots' until SDR is fixed
-            : `${dxDirectory}/${metadataTypeEntry.directoryName}`,
+        metadataPath: `${dxDirectory}/${metadataTypeEntry.directoryName}`,
         uniqueIdElements: getUniqueIdElements(metadataTypeToRetrieve)
           ? `${defaultuniqueIdElements},${getUniqueIdElements(metadataTypeToRetrieve)}`
           : defaultuniqueIdElements,

--- a/src/commands/decomposer/recompose.ts
+++ b/src/commands/decomposer/recompose.ts
@@ -68,10 +68,7 @@ export default class DecomposerRecompose extends SfCommand<DecomposerRecomposeRe
         xmlElement: metadataTypeEntry.name,
         strictDirectoryName: metadataTypeEntry.strictDirectoryName as boolean,
         folderType: metadataTypeEntry.folderType as string,
-        metadataPath:
-          metadataTypeToRetrieve === 'botVersion'
-            ? `${dxDirectory}/bots` // Change the directoryName to 'bots' until SDR is fixed
-            : `${dxDirectory}/${metadataTypeEntry.directoryName}`,
+        metadataPath: `${dxDirectory}/${metadataTypeEntry.directoryName}`,
       };
 
       await recomposeFileHandler(metaAttributes, debug);

--- a/src/service/decomposeFileHandler.ts
+++ b/src/service/decomposeFileHandler.ts
@@ -23,7 +23,8 @@ export async function decomposeFileHandler(
   if (debug) {
     setLogLevel('debug');
   }
-  // additional purge for labels
+  // standalone purge is required for labels
+  // do not use the purge flag in the xml-disassembler package for labels due to file moving
   if (metaSuffix === 'labels' && purge) {
     const subFiles = await fs.readdir(metadataPath);
     for (const subFile of subFiles) {

--- a/src/service/decomposeFileHandler.ts
+++ b/src/service/decomposeFileHandler.ts
@@ -6,7 +6,6 @@ import fs from 'fs-extra';
 
 import { DisassembleXMLFileHandler, setLogLevel } from 'xml-disassembler';
 import { CUSTOM_LABELS_FILE } from '../helpers/constants.js';
-import { renameBotVersionFile } from './renameBotVersionFiles.js';
 
 export async function decomposeFileHandler(
   metaAttributes: {
@@ -82,8 +81,5 @@ export async function decomposeFileHandler(
         await fs.remove(subdirectoryPath);
       }
     }
-  }
-  if (metaSuffix === 'bot') {
-    await renameBotVersionFile(metadataPath);
   }
 }

--- a/src/service/moveFiles.ts
+++ b/src/service/moveFiles.ts
@@ -1,0 +1,21 @@
+'use strict';
+/* eslint-disable no-await-in-loop */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as fsextra from 'fs-extra';
+
+export async function moveFiles(
+  sourceDirectory: string,
+  destinationDirectory: string,
+  predicate: (fileName: string) => boolean
+): Promise<void> {
+  const files = await fs.readdir(sourceDirectory);
+  for (const file of files) {
+    const fileStat = await fs.stat(path.join(sourceDirectory, file));
+    if (fileStat.isFile() && predicate(file)) {
+      const sourceFile = path.join(sourceDirectory, file);
+      const destinationFile = path.join(destinationDirectory, file);
+      await fsextra.move(sourceFile, destinationFile, { overwrite: true });
+    }
+  }
+}

--- a/src/service/recomposeFileHandler.ts
+++ b/src/service/recomposeFileHandler.ts
@@ -6,22 +6,7 @@ import * as fsextra from 'fs-extra';
 import { ReassembleXMLFileHandler, setLogLevel } from 'xml-disassembler';
 import { CUSTOM_LABELS_FILE } from '../helpers/constants.js';
 import { renameBotVersionFile } from './renameBotVersionFiles.js';
-
-async function moveFiles(
-  sourceDirectory: string,
-  destinationDirectory: string,
-  predicate: (fileName: string) => boolean
-): Promise<void> {
-  const files = await fs.readdir(sourceDirectory);
-  for (const file of files) {
-    const fileStat = await fs.stat(path.join(sourceDirectory, file));
-    if (fileStat.isFile() && predicate(file)) {
-      const sourceFile = path.join(sourceDirectory, file);
-      const destinationFile = path.join(destinationDirectory, file);
-      await fsextra.move(sourceFile, destinationFile, { overwrite: true });
-    }
-  }
-}
+import { moveFiles } from './moveFiles.js';
 
 async function reassembleHandler(xmlPath: string, fileExtension: string): Promise<void> {
   const handler = new ReassembleXMLFileHandler();

--- a/test/commands/decomposer/e2e.test.ts
+++ b/test/commands/decomposer/e2e.test.ts
@@ -10,6 +10,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { TestContext } from '@salesforce/core/lib/testSetup.js';
 import { expect } from 'chai';
 import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import { setLogLevel } from 'xml-disassembler';
 import DecomposerRecompose from '../../../src/commands/decomposer/recompose.js';
 import DecomposerDecompose from '../../../src/commands/decomposer/decompose.js';
 
@@ -45,6 +46,7 @@ describe('e2e', () => {
 
   before(async () => {
     sfCommandStubs = stubSfCommandUx($$.SANDBOX);
+    setLogLevel('debug');
 
     // Create a mock directory by copying the original directory
     await copyAsync(originalDirectory, mockDirectory);

--- a/test/commands/decomposer/e2e.test.ts
+++ b/test/commands/decomposer/e2e.test.ts
@@ -5,7 +5,6 @@ import * as assert from 'node:assert';
 import * as path from 'node:path';
 import * as fsPromises from 'node:fs/promises';
 import * as fsSync from 'fs-extra';
-import { XMLParser } from 'fast-xml-parser';
 
 import { TestContext } from '@salesforce/core/lib/testSetup.js';
 import { expect } from 'chai';
@@ -124,43 +123,23 @@ describe('e2e', () => {
   });
 });
 
-interface XmlElement {
-  [key: string]: string | XmlElement | string[] | XmlElement[];
-}
-
-const XML_PARSER_OPTION = {
-  commentPropName: '!---',
-  ignoreAttributes: false,
-  ignoreNameSpace: false,
-  parseTagValue: false,
-  parseNodeValue: false,
-  parseAttributeValue: false,
-  trimValues: true,
-  processEntities: false,
-  cdataPropName: '![CDATA[',
-};
-
-function compareXmls(referenceXml: string, mockXml: string): void {
-  const xmlParser = new XMLParser(XML_PARSER_OPTION);
-  const referenceParsed = xmlParser.parse(referenceXml) as Record<string, XmlElement>;
-  const mockParsed = xmlParser.parse(mockXml) as Record<string, XmlElement>;
-
-  assert.deepStrictEqual(referenceParsed, mockParsed, 'XML content is different');
-}
-
 function compareDirectories(referenceDir: string, mockDir: string): void {
-  const entriesInRef = fs.readdirSync(referenceDir, { withFileTypes: true });
+  const entriesinRef = fs.readdirSync(referenceDir, { withFileTypes: true });
 
-  for (const entry of entriesInRef) {
+  // Only compare files that are in the reference directory (composed files)
+  // Ignore files only found in the mock directory (decomposed files)
+  for (const entry of entriesinRef) {
     const refEntryPath = path.join(referenceDir, entry.name);
     const mockPath = path.join(mockDir, entry.name);
 
     if (entry.isDirectory()) {
+      // If it's a directory, recursively compare its contents
       compareDirectories(refEntryPath, mockPath);
     } else {
+      // If it's a file, compare its content
       const refContent = fs.readFileSync(refEntryPath, 'utf-8');
       const mockContent = fs.readFileSync(mockPath, 'utf-8');
-      compareXmls(refContent, mockContent);
+      assert.strictEqual(refContent, mockContent, `File content is different for ${entry.name}`);
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12346,10 +12346,10 @@ write-file-atomic@^5.0.0, write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-xml-disassembler@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/xml-disassembler/-/xml-disassembler-1.0.6.tgz"
-  integrity sha512-nCDGXEYUXQWnA5FsyQiXUlMBw1MW4hva7iLoUOVyPe3qBrqKGdazzW47kxl4Z0mRhnciHBjQiNR4cDjzefd2PQ==
+xml-disassembler@^1.0.10-beta.1:
+  version "1.0.10-beta.1"
+  resolved "https://registry.npmjs.org/xml-disassembler/-/xml-disassembler-1.0.10-beta.1.tgz"
+  integrity sha512-qwf6c1Q5Dvi7/Xs6E8aqAqb1LqPTz7lqRzZkrYwqKy7fmsKxFTRsimm11s8G2vKWCgIQNU3srlo94KKj/TKxzQ==
   dependencies:
     fast-xml-parser "^4.3.4"
     log4js "^6.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12346,10 +12346,10 @@ write-file-atomic@^5.0.0, write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-xml-disassembler@^1.0.10-beta.1:
-  version "1.0.10-beta.1"
-  resolved "https://registry.npmjs.org/xml-disassembler/-/xml-disassembler-1.0.10-beta.1.tgz"
-  integrity sha512-qwf6c1Q5Dvi7/Xs6E8aqAqb1LqPTz7lqRzZkrYwqKy7fmsKxFTRsimm11s8G2vKWCgIQNU3srlo94KKj/TKxzQ==
+xml-disassembler@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.npmjs.org/xml-disassembler/-/xml-disassembler-1.0.10.tgz"
+  integrity sha512-u+llAvXaK+sqABpP0Hbses2bdRjIVkRkPwyEhd2Br8IOG6gaoUjIIdVJ8RQM5412IP+d0Qt3mgdFi1y2yD3qcA==
   dependencies:
     fast-xml-parser "^4.3.4"
     log4js "^6.9.1"


### PR DESCRIPTION
This solves a weird issue seen when recomposing files like "profiles" which have a leaf file and nested element files.

The sorting when ran in Windows locally would process the nested sub-directories first, then the leaf file last when recomposing. This would pass the comparison test (last test in suite).

When pushing a v3 build back to GitHub, the same compare test would fail in the Ubuntu container due to the leaf file being added first to the recomposed file, follow by the sub-directories.

The xml-disassembler package sorts files based on name in the nested sub-directories, but this code was missing when sorting the files/sub-directories in the initial root folder.